### PR TITLE
chore: Automatically update the version based on Github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
         run: |
           npm run test
 
+      - name: Set version
+        run: |
+          # Extract version from the tag (eg. v1.0.0 -> 1.0.0)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          # Update the version in package.json
+          npm version $VERSION --no-git-tag-version
+
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-canvas",
-  "version": "0.2.2",
+  "version": "0.0.0-automated",
   "description": "A Prettier plugin for Blutui Canvas",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds the ability to update the package.json version using a Github release version and tag.