### PR TITLE
chore: add tests for extends tag

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,9 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["vitest.explorer"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "EditorConfig.EditorConfig",
+    "vitest.explorer"
+  ]
 }

--- a/tests/canvas-tag-extends/index.test.ts
+++ b/tests/canvas-tag-extends/index.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest'
+
+import { format, heredoc } from 'tests/utils'
+
+describe('Canvas Tag: Extends', () => {
+  test('it should never break a name', async () => {
+    const result = await format(
+      heredoc`
+        {% extends  "base.canvas" %}
+        {% extends "base.canvas" %}
+        {%extends "base.canvas"%}
+        {%- extends
+        "base.canvas"
+        -%}
+        {%- extends none -%}
+      `,
+      { printWidth: 1 }
+    )
+
+    expect(result).toBe(
+      heredoc`
+        {% extends "base.canvas" %}
+        {% extends "base.canvas" %}
+        {% extends "base.canvas" %}
+        {%- extends "base.canvas" -%}
+        {%- extends none -%}
+      `
+    )
+  })
+
+  test('it correctly formats a child template', async () => {
+    const result = await format(
+      heredoc`
+        {% extends  "base.canvas" %}
+
+        {% block title %}Index{% endblock %}
+      `
+    )
+
+    expect(result).toBe(
+      heredoc`
+        {% extends "base.canvas" %}
+
+        {% block title %}Index{% endblock %}
+      `
+    )
+  })
+
+  test('issue #16', async () => {
+    const result = await format(
+      heredoc`
+        {% extends 'components/layouts/default' %}
+
+        {% set contact = cms.collection('contact') %}
+
+        {% block styles %}{% endblock %}
+        {% block body %}
+      `
+    )
+
+    expect(result).toBe(
+      heredoc`
+        {% extends 'components/layouts/default' %}
+
+        {% set contact = cms.collection('contact') %}
+
+        {% block styles %}{% endblock %}
+        {% block body %}
+      `
+    )
+  })
+})


### PR DESCRIPTION
This PR adds tests for the `extends` tag.

Fixes #16